### PR TITLE
Update Authorization Header after refresh

### DIFF
--- a/proton/api.py
+++ b/proton/api.py
@@ -168,6 +168,7 @@ WO4BAMcm1u02t4VKw++ttECPt+HUgPUq5pqQWe5Q2cW4TMsE
         })
         self._session_data['AccessToken'] = refresh_response["AccessToken"]
         self._session_data['RefreshToken'] = refresh_response["RefreshToken"]
+        self.s.headers['Authorization'] = 'Bearer ' + self.AccessToken
 
     @property
     def UID(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ wrapper to the Proton Technologies API, abstracting from the SRP authentication.
 '''
 
 setup(name             = 'proton-client',
-      version          = '0.0.2',
+      version          = '0.0.3',
       description      = 'Proton Technologies API wrapper',
       author           = 'Proton Technologies',
       author_email     = 'contact@protonmail.com',


### PR DESCRIPTION
Without this, you can't make new api requests after a refresh, as the headers are still using the old Access Token. 