### PR TITLE
Migrated to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core      import setup
-from distutils.extension import Extension
+from setuptools import setup, find_packages
 
 
 long_description = '''
@@ -10,19 +9,19 @@ This package, originally forked from python-srp module implements a simple
 wrapper to the Proton Technologies API, abstracting from the SRP authentication.
 '''
 
-setup(name             = 'proton-client',
-      version          = '0.0.3',
-      description      = 'Proton Technologies API wrapper',
-      author           = 'Proton Technologies',
-      author_email     = 'contact@protonmail.com',
-      url              = 'https://github.com/ProtonMail/proton-python-client',
-      long_description = long_description,
-      install_requires = ['requests', 'bcrypt', 'gnupg'],
-      packages         = ['proton'],
-      package_data     = {'proton' : ['doc/*.rst', 'doc/*.py']},
-      license          = "MIT",
-      platforms        = "OS Independent",
-      classifiers      = [
+setup(name                  = 'proton-client',
+      version               = '0.0.3',
+      description           = 'Proton Technologies API wrapper',
+      author                = 'Proton Technologies',
+      author_email          = 'contact@protonmail.com',
+      url                   = 'https://github.com/ProtonMail/proton-python-client',
+      long_description      = long_description,
+      install_requires      = ['requests', 'bcrypt', 'gnupg'],
+      packages              = find_packages(),
+      include_package_data  = True,
+      license               = "MIT",
+      platforms             = "OS Independent",
+      classifiers           = [
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
- find_packages() is used to automatically find and detect packages

- Also, no need to specify which package data is to be included, since `include_package_data = True` already includes all data based on the `MANIFEST.in` file