### PR TITLE
document lack of proper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The recommended way to install the client is via OS-respective packages (.deb/.r
 
 # Usage
 
+Sadly, there is no documenattion of API but this repository may make easier to reverse enginner automatic interaction with Proton.
+
 ## Import
 `from proton.api import Session, ProtonError`
 


### PR DESCRIPTION
as  #34 remains unanswered since 2021 admitting lack of proper documentation would be a good first step

(to avoid XY problem - I am checking whether Proton mail is capable of replacing Gmail, the first found blocker is inability to import email filters - though maybe Sieve mentioned in settings can be one giant filter handling thousands of rules at once...)

EDIT: Filtering support appears to be extremely limited. https://protonmail.uservoice.com/forums/284483-proton-mail/suggestions/17380327-remove-number-of-active-filters-limit implies that even paid user can have at most 50 filters. Well, lets find another email provider. Fastmail seems to have proper filter support, and at least claims to be able to import what Gmail supports.