### PR TITLE
Fix a source of the 'Unknown API error.'

### DIFF
--- a/proton/cert_pinning.py
+++ b/proton/cert_pinning.py
@@ -44,7 +44,6 @@ class TLSPinningHTTPSConnectionPool(HTTPSConnectionPool):
             super(TLSPinningHTTPSConnectionPool, self).__init__(
                 host,
                 port,
-                strict,
                 timeout,
                 maxsize,
                 block,
@@ -67,7 +66,6 @@ class TLSPinningHTTPSConnectionPool(HTTPSConnectionPool):
             super(TLSPinningHTTPSConnectionPool, self).__init__(
                 host,
                 port,
-                strict,
                 timeout,
                 maxsize,
                 block,


### PR DESCRIPTION
Hello dear Proton team and community,

Since November 2020 the parameter `strict` was removed from urllib3 for `HTTPSConnectionPool` class in [connectionpool.py](https://github.com/urllib3/urllib3/pull/2064). Leaving the parameter `strict` in the call is shifting the next ones and `timeout` is taken as a boolean leading to the error `'Timeout cannot be a boolean, it must be an...'` raising an `UnknownConnectionError` in [api.py](https://github.com/ProtonMail/proton-python-client/blob/master/proton/api.py#L345) and finally the famous `UnknownAPIError` in the [cli_wrapper.py](https://github.com/ProtonVPN/linux-cli/blob/master/protonvpn_cli/cli_wrapper.py#L106).

This explains why so many people on forums have their proton cli not working after updating their packages with urllib3 among them.